### PR TITLE
tags_regex argument and provider version uppdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "0.35.0"
+      version = "0.36.1"
     }
   }
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "0.35.0"
+      version = "0.36.1"
     }
   }
 

--- a/examples/count/main.tf
+++ b/examples/count/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "0.35.0"
+      version = "0.36.1"
     }
   }
 

--- a/examples/for-each/main.tf
+++ b/examples/for-each/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "0.35.0"
+      version = "0.36.1"
     }
   }
 

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "0.35.0"
+      version = "0.36.1"
     }
   }
 
@@ -59,6 +59,7 @@ module "workspacer" {
       state_versions    = "read-outputs"
       sentinel_mocks    = "read"
       workspace_locking = true
+      runs_tasks        = "read"
     }
     custom-team-2 = {
       runs              = "read"
@@ -66,6 +67,7 @@ module "workspacer" {
       state_versions    = "read"
       sentinel_mocks    = "none"
       workspace_locking = false
+      runs_tasks        = "read"
     }
   }
 

--- a/examples/with-vcs/main.tf
+++ b/examples/with-vcs/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "0.35.0"
+      version = "0.36.1"
     }
   }
 }
@@ -17,7 +17,7 @@ module "workspacer" {
   organization      = var.organization
   workspace_name    = "workspacer-module-with-vcs-test"
   workspace_desc    = "Created by Terraform Workspacer module."
-  workspace_tags    = ["module-ci", "test", "aws"] 
+  workspace_tags    = ["module-ci", "test", "aws"]
   auto_apply        = true
   working_directory = "/tests/with-vcs/tf-working-dir-test"
 

--- a/variable_sets.tf
+++ b/variable_sets.tf
@@ -1,13 +1,13 @@
 data "tfe_variable_set" "vs" {
   for_each = toset(var.variable_set_names)
-  
+
   name         = each.value
   organization = var.organization
 }
 
 resource "tfe_workspace_variable_set" "vs" {
   for_each = data.tfe_variable_set.vs
-  
+
   variable_set_id = each.value.id
   workspace_id    = tfe_workspace.ws.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -112,6 +112,12 @@ variable "trigger_prefixes" {
   default     = null
 }
 
+variable "tags_regex" {
+  type        = string
+  description = "A regular expression used to trigger a Workspace run for matching Git tags. This option conflicts with `trigger_patterns` and `trigger_prefixes`. Should only set this value if the former is not being used."
+  default     = null
+}
+
 variable "speculative_enabled" {
   type        = bool
   description = "Boolean to allow Speculative Plans on Workspace."

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = ">= 0.32.1"
+      version = ">= 0.36.0"
     }
   }
 

--- a/workspace.tf
+++ b/workspace.tf
@@ -21,6 +21,7 @@ resource "tfe_workspace" "ws" {
       branch             = lookup(var.vcs_repo, "branch", null)
       oauth_token_id     = lookup(var.vcs_repo, "oauth_token_id", null)
       ingress_submodules = lookup(var.vcs_repo, "ingress_submodules", null)
+      tags_regex         = lookup(var.vcs_repo, "tags_regex", null)
     }
   }
 


### PR DESCRIPTION
* Example tfe providers versions updated to 0.36.1 for support of the  `tags_regex` argument.
* examples/full/main.tf added `run_tasks`
* terraform fmt
* `tags_regex` argument added to variables.tf and workspaces.tf