### PR TITLE
Add force delete option to workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ provider "tfe" {
 
 module "workspacer" {
   source  = "alexbasista/workspacer/tfe"
-  version = "0.6.1"
+  version = "0.7.0"
 
   organization   = "my-tfe-org"
   workspace_name = "my-new-ws"

--- a/variables.tf
+++ b/variables.tf
@@ -136,6 +136,12 @@ variable "tags_regex" {
   default     = null
 }
 
+variable "force_delete" {
+  type        = bool
+  description = "Bool that if configured to true will allow deletion of the workspace if there is a state with resources provisioned"
+  default     = null
+}
+
 #------------------------------------------------------------------------------
 # Workspace Variables
 #------------------------------------------------------------------------------

--- a/workspace.tf
+++ b/workspace.tf
@@ -19,6 +19,7 @@ resource "tfe_workspace" "ws" {
   trigger_prefixes              = var.trigger_prefixes
   trigger_patterns              = var.trigger_patterns
   working_directory             = var.working_directory
+  force_delete                  = var.force_delete
 
   dynamic "vcs_repo" {
     for_each = lookup(var.vcs_repo, "identifier", null) == null ? [] : [var.vcs_repo]


### PR DESCRIPTION
Workspaces now support a safe deletion by default so they can't be deleted if there are resources that are still in the state. https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace#force_delete
This PR adds this variable as default null, which is the same as true, however it can be overridden as false if needed 
