### PR TITLE
Run Trigger datasource count fix

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "0.38.0"
+      version = "0.42.0"
     }
   }
 }

--- a/examples/count/main.tf
+++ b/examples/count/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "0.38.0"
+      version = "0.42.0"
     }
   }
 }

--- a/examples/for-each/main.tf
+++ b/examples/for-each/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "0.38.0"
+      version = "0.42.0"
     }
   }
 }

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "0.38.0"
+      version = "0.42.0"
     }
   }
 }

--- a/examples/with-vcs/main.tf
+++ b/examples/with-vcs/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "0.38.0"
+      version = "0.42.0"
     }
   }
 }

--- a/run_triggers.tf
+++ b/run_triggers.tf
@@ -1,12 +1,12 @@
 data "tfe_workspace_ids" "run_triggers" {
-  count = var.run_trigger_source_workspaces == [] ? 0 : 1
+  count = length(var.run_trigger_source_workspaces) == 0 ? 0 : 1
 
   names        = var.run_trigger_source_workspaces
   organization = var.organization
 }
 
 resource "tfe_run_trigger" "rt" {
-  for_each = data.tfe_workspace_ids.run_triggers[0].ids
+  for_each = length(var.run_trigger_source_workspaces) == 0 ? {} : data.tfe_workspace_ids.run_triggers[0].ids
 
   workspace_id  = tfe_workspace.ws.id
   sourceable_id = each.value

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = ">= 0.38.0"
+      version = ">= 0.42.0"
     }
   } 
 }


### PR DESCRIPTION
This PR is a performance/efficiency improvement with how Terraform was behaving with the `count` logic on the `tfe_workspace_ids.run_triggers` data source.  Previously, the data source was doing a read operation even when the count of `var.run_trigger_source_workspaces` was `0`.  These changes make it so that data source does not trigger when the count is set to `0`.