### PR TITLE
Add Workspace Policy Sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,5 +167,16 @@ To add the Workspace into one or more already existing Variable Sets, the input 
 ```
 <p>&nbsp;</p>
 
+### Policy Sets
+To add the Workspace into one or more already existing Policy Sets, the input variable `policy_set_names` accepts a list of Policy Set names.
+
+```hcl
+  policy_set_names = [
+    "sentinel-global",
+    "sentinel-prod"
+  ]
+```
+<p>&nbsp;</p>
+
 ## Limitations
 - Due to some current provider-interfacing/API challenges with Workspace Variables, any non-string Workspace Variable value (where the `hcl` attribute would equal `true`) will be JSON-encoded and subsequently any `:` characters will be replaced with `=`. Therefore, _non-string_ Workspace Variable values that contain a colon character are not currently supported.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ To add the Workspace into one or more already existing Variable Sets, the input 
     "tfe-api-token"
   ]
 ```
-<p>&nbsp;</p>
 
 ### Policy Sets
 To add the Workspace into one or more already existing Policy Sets, the input variable `policy_set_names` accepts a list of Policy Set names.

--- a/policy_sets.tf
+++ b/policy_sets.tf
@@ -1,0 +1,13 @@
+data "tfe_policy_set" "ps" {
+  for_each = toset(var.policy_set_names)
+
+  name         = each.value
+  organization = var.organization
+}
+
+resource "tfe_workspace_policy_set" "ps" {
+  for_each = data.tfe_policy_set.ps
+  
+  policy_set_id = each.value.id
+  workspace_id  = tfe_workspace.ws.id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -246,3 +246,12 @@ variable "variable_set_names" {
   description = "List of names of existing Variable Sets to add this Workspace into."
   default     = []
 }
+
+#------------------------------------------------------------------------------
+# Workspace Policy Sets
+#------------------------------------------------------------------------------
+variable "policy_set_names" {
+  type        = list(string)
+  description = "List of names of existing Policy Sets to add this Workspace into."
+  default     = []
+}


### PR DESCRIPTION
This PR adds the ability to pass in existing Policy Set names that the Workspace should be added to upon creation.