### PR TITLE
feat: add project_id input

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,13 +239,13 @@ $ curl  --header "Authorization: Bearer $TFE_TOKEN \
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_tfe"></a> [tfe](#requirement\_tfe) | ~> 0.62 |
+| <a name="requirement_tfe"></a> [tfe](#requirement\_tfe) | ~> 0.72 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | ~> 0.62 |
+| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | ~> 0.72 |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,19 @@ See the [examples](./examples) directory for more detailed example scenarios, an
 
 ### Projects
 
-To place the Workspace into an existing Project, set the input variable `project_name`.
+To place the Workspace into an existing Project, there are two options. These are mutually exclusive, so only one should be set at a time.
+
+#### By `project_id`
+
+This option is more performant at scale because the `tfe_project` data source is not invoked to lookup the Project ID by name, which saves a read request per Workspace.
+
+```hcl
+project_id = "prj-abcdefg123456789"
+```
+
+#### By `project_name`
+
+This option is more convenient at smaller scale, as you can pass in the Project name and the module fetch the ID via the `tfe_project` data source.
 
 ```hcl
 project_name = "my-project"
@@ -43,7 +55,6 @@ project_name = "my-project"
 ### With VCS
 
 The optional `vcs_repo` input variable expects a map of key/value pairs with up to six attributes.
-
 
 #### Using an OAuth Token
 
@@ -234,11 +245,7 @@ $ curl  --header "Authorization: Bearer $TFE_TOKEN \
 
 | Name | Version |
 |------|---------|
-| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | 0.67.1 |
-
-## Modules
-
-No modules.
+| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | ~> 0.62 |
 
 ## Resources
 
@@ -285,7 +292,8 @@ No modules.
 | <a name="input_global_remote_state"></a> [global\_remote\_state](#input\_global\_remote\_state) | Boolean to allow all Workspaces within the Organization to remotely access the State of this Workspace. | `bool` | `false` | no |
 | <a name="input_notifications"></a> [notifications](#input\_notifications) | List of Notification objects to configure on Workspace. | <pre>list(<br/>    object(<br/>      {<br/>        name             = string<br/>        destination_type = string<br/>        url              = optional(string)<br/>        token            = optional(string)<br/>        email_addresses  = optional(list(string))<br/>        email_user_ids   = optional(list(string))<br/>        triggers         = list(string)<br/>        enabled          = bool<br/>      }<br/>    )<br/>  )</pre> | `[]` | no |
 | <a name="input_policy_set_names"></a> [policy\_set\_names](#input\_policy\_set\_names) | List of names of existing Policy Sets to add this Workspace into. | `list(string)` | `[]` | no |
-| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Name of existing Project to create Workspace in. | `string` | `null` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of existing Project to create Workspace in. Must be `null` if `project_name` is set. | `string` | `null` | no |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Name of existing Project to create Workspace in. Must be `null` if `project_id` is set. | `string` | `null` | no |
 | <a name="input_queue_all_runs"></a> [queue\_all\_runs](#input\_queue\_all\_runs) | Boolean setting for Workspace to automatically queue all Runs after creation. | `bool` | `true` | no |
 | <a name="input_remote_state_consumer_ids"></a> [remote\_state\_consumer\_ids](#input\_remote\_state\_consumer\_ids) | List of existing Workspace IDs allowed to remotely access the State of Workspace. | `list(string)` | `null` | no |
 | <a name="input_run_trigger_source_workspaces"></a> [run\_trigger\_source\_workspaces](#input\_run\_trigger\_source\_workspaces) | List of existing Workspace names that will trigger runs on Workspace. | `list(string)` | `[]` | no |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -4,7 +4,7 @@ provider "tfe" {
 
 module "workspacer" {
   source  = "alexbasista/workspacer/tfe"
-  version = "0.13.0"
+  version = "0.14.0"
 
   organization   = "<my-org-name>"
   workspace_name = "workspacer-basic-example"

--- a/examples/count/main.tf
+++ b/examples/count/main.tf
@@ -4,7 +4,7 @@ provider "tfe" {
 
 module "workspacer" {
   source  = "alexbasista/workspacer/tfe"
-  version = "0.13.0"
+  version = "0.14.0"
   count   = 8
 
   organization   = "<my-org-name>"

--- a/examples/for-each/main.tf
+++ b/examples/for-each/main.tf
@@ -4,7 +4,7 @@ provider "tfe" {
 
 module "workspacer" {
   source   = "alexbasista/workspacer/tfe"
-  version  = "0.13.0"
+  version  = "0.14.0"
   for_each = var.workspaces
 
   organization       = var.organization

--- a/examples/with-vcs/main.tf
+++ b/examples/with-vcs/main.tf
@@ -4,7 +4,7 @@ provider "tfe" {
 
 module "workspacer_vcs_oauth_token" {
   source  = "alexbasista/workspacer/tfe"
-  version = "0.13.0"
+  version = "0.14.0"
 
   organization   = "<my-org-name>"
   workspace_name = "workspacer-vcs-oauth-ex"
@@ -32,7 +32,7 @@ module "workspacer_vcs_oauth_token" {
 
 module "workspacer_vcs_github_app" {
   source  = "alexbasista/workspacer/tfe"
-  version = "0.13.0"
+  version = "0.14.0"
 
   organization   = "<my-org-name>"
   workspace_name = "workspacer-vcs-github-app-ex"

--- a/tests/basic/main.tf
+++ b/tests/basic/main.tf
@@ -6,6 +6,7 @@ module "workspacer" {
   source = "../.."
 
   organization   = var.organization
+  project_name   = "Default Project"
   workspace_name = "workspacer-basic-example"
   workspace_desc = "Created by 'workspacer' Terraform module."
   workspace_map_tags = {
@@ -13,7 +14,6 @@ module "workspacer" {
     "env"   = "test",
     "cloud" = "aws"
   }
-  project_name = "Default Project"
 
   tfvars = {
     example_var = "example_value"

--- a/tests/with-vcs/main.tf
+++ b/tests/with-vcs/main.tf
@@ -6,13 +6,13 @@ module "workspacer_oauth_token" {
   source = "../.."
 
   organization   = var.organization
+  project_name   = "Default Project"
   workspace_name = "workspacer-vcs-oauth-ex"
   workspace_map_tags = {
     "app"   = "acme",
     "env"   = "test",
     "cloud" = "aws"
   }
-  project_name = "Default Project"
 
   working_directory     = "/tests/with-vcs/tf-working-dir-test"
   auto_apply            = true

--- a/variables.tf
+++ b/variables.tf
@@ -176,10 +176,21 @@ variable "force_delete" {
   default     = null
 }
 
+variable "project_id" {
+  type        = string
+  description = "ID of existing Project to create Workspace in. Must be `null` if `project_name` is set."
+  default     = null
+}
+
 variable "project_name" {
   type        = string
-  description = "Name of existing Project to create Workspace in."
+  description = "Name of existing Project to create Workspace in. Must be `null` if `project_id` is set."
   default     = null
+
+  validation {
+    condition     = var.project_id != null ? var.project_name == null : true
+    error_message = "`project_id` and `project_name` are mutually exclusive; only one may be set."
+  }
 }
 
 #------------------------------------------------------------------------------

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "~> 0.62"
+      version = "~> 0.72"
     }
   }
 }

--- a/workspace.tf
+++ b/workspace.tf
@@ -17,7 +17,7 @@ resource "tfe_workspace" "ws" {
   trigger_patterns              = var.trigger_patterns
   working_directory             = var.working_directory
   force_delete                  = var.force_delete
-  project_id                    = var.project_name != null ? data.tfe_project.ws[0].id : null
+  project_id                    = var.project_id != null ? var.project_id : (var.project_name != null ? data.tfe_project.ws[0].id : null)
 
   dynamic "vcs_repo" {
     for_each = var.vcs_repo != null ? [var.vcs_repo] : []


### PR DESCRIPTION
Previously, the only way to configure your Workspace in an existing Project was to specify a value of the `project_name` input, which then invokes a `tfe_project` data source lookup to fetch the Project ID to pass to the `project_id` argument of the `tfe_workspace` resource.

This change adds an input (`var.project_id`) to pass the Project ID in directly, which avoids the invocation of the `tfe_project` data source, which improves performance at scale by saving an extra read request per Workspace.