### PR TITLE
Make tfe_workspace_settings resource conditional

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ module "workspacer" {
   version = "x.x.x"
 
   organization   = "my-hcptf-or-tfe-org-name"
+  project_name   = "Default Project"
   workspace_name = "my-new-ws"
   workspace_desc = "Description of my new Workspace."
   workspace_map_tags = {
-    "app" = "acme", 
-    "env" = "test",
+    "app"   = "acme",
+    "env"   = "test",
     "cloud" = "aws"
   }
-  project_name   = "Default Project"
 
   tfvars = {
     teststring = "iamstring"
@@ -46,7 +46,7 @@ project_id = "prj-abcdefg123456789"
 
 #### By `project_name`
 
-This option is more convenient at smaller scale, as you can pass in the Project name and the module fetch the ID via the `tfe_project` data source.
+This option is more convenient at smaller scale, as you can pass in the Project name and the module fetches the ID via the `tfe_project` data source.
 
 ```hcl
 project_name = "my-project"
@@ -289,7 +289,7 @@ $ curl  --header "Authorization: Bearer $TFE_TOKEN \
 | <a name="input_execution_mode"></a> [execution\_mode](#input\_execution\_mode) | Execution mode of Workspace. Valid values are `remote`, `local`, or `agent`. | `string` | `null` | no |
 | <a name="input_file_triggers_enabled"></a> [file\_triggers\_enabled](#input\_file\_triggers\_enabled) | Boolean to filter Runs triggered via webhook (VCS push) based on `working_directory` and `trigger_prefixes`. | `bool` | `true` | no |
 | <a name="input_force_delete"></a> [force\_delete](#input\_force\_delete) | Boolean to allow deletion of the Workspace if there is a Terraform state that contains resources. | `bool` | `null` | no |
-| <a name="input_global_remote_state"></a> [global\_remote\_state](#input\_global\_remote\_state) | Boolean to allow all Workspaces within the Organization to remotely access the State of this Workspace. | `bool` | `false` | no |
+| <a name="input_global_remote_state"></a> [global\_remote\_state](#input\_global\_remote\_state) | Boolean to allow all Workspaces within the Organization to remotely access the State of this Workspace. | `bool` | `null` | no |
 | <a name="input_notifications"></a> [notifications](#input\_notifications) | List of Notification objects to configure on Workspace. | <pre>list(<br/>    object(<br/>      {<br/>        name             = string<br/>        destination_type = string<br/>        url              = optional(string)<br/>        token            = optional(string)<br/>        email_addresses  = optional(list(string))<br/>        email_user_ids   = optional(list(string))<br/>        triggers         = list(string)<br/>        enabled          = bool<br/>      }<br/>    )<br/>  )</pre> | `[]` | no |
 | <a name="input_policy_set_names"></a> [policy\_set\_names](#input\_policy\_set\_names) | List of names of existing Policy Sets to add this Workspace into. | `list(string)` | `[]` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of existing Project to create Workspace in. Must be `null` if `project_name` is set. | `string` | `null` | no |

--- a/tests/basic/main.tf
+++ b/tests/basic/main.tf
@@ -7,7 +7,7 @@ module "workspacer" {
 
   organization   = var.organization
   project_name   = "Default Project"
-  workspace_name = "workspacer-basic-example"
+  workspace_name = "workspacer-test-basic"
   workspace_desc = "Created by 'workspacer' Terraform module."
   workspace_map_tags = {
     "app"   = "acme",

--- a/variables.tf
+++ b/variables.tf
@@ -17,17 +17,6 @@ variable "workspace_desc" {
   default     = "Created by 'workspacer' Terraform module."
 }
 
-variable "agent_pool_id" {
-  type        = string
-  description = "ID of existing Agent Pool to assign to Workspace. Only valid when `execution_mode` is set to `agent`."
-  default     = null
-
-  validation {
-    condition     = var.execution_mode == "agent" ? var.agent_pool_id != null : true
-    error_message = "Value must be set if `execution_mode` is set to `agent`."
-  }
-}
-
 variable "allow_destroy_plan" {
   type        = bool
   description = "Boolean setting to allow destroy plans on Workspace."
@@ -51,6 +40,22 @@ variable "execution_mode" {
   }
 }
 
+variable "agent_pool_id" {
+  type        = string
+  description = "ID of existing Agent Pool to assign to Workspace. Only valid when `execution_mode` is set to `agent`."
+  default     = null
+
+  validation {
+    condition     = var.execution_mode == "agent" ? var.agent_pool_id != null : true
+    error_message = "Value must be set if `execution_mode` is set to `agent`."
+  }
+
+  validation {
+    condition     = var.agent_pool_id != null ? var.execution_mode == "agent" : true
+    error_message = "Value cannot be set unless `execution_mode` is set to `agent`."
+  }
+}
+
 variable "assessments_enabled" {
   type        = bool
   description = "Boolean to enable Health Assessments such as Drift Detection on Workspace."
@@ -66,7 +71,7 @@ variable "file_triggers_enabled" {
 variable "global_remote_state" {
   type        = bool
   description = "Boolean to allow all Workspaces within the Organization to remotely access the State of this Workspace."
-  default     = false
+  default     = null
 }
 
 variable "remote_state_consumer_ids" {

--- a/workspace.tf
+++ b/workspace.tf
@@ -34,12 +34,16 @@ resource "tfe_workspace" "ws" {
 }
 
 resource "tfe_workspace_settings" "ws" {
+  count = (
+    var.execution_mode == null &&
+    var.global_remote_state == null &&
+    var.remote_state_consumer_ids == null
+  ) ? 0 : 1
+
   workspace_id              = tfe_workspace.ws.id
   execution_mode            = var.execution_mode
+  agent_pool_id             = var.execution_mode == "agent" ? var.agent_pool_id : null
   global_remote_state       = var.global_remote_state
   remote_state_consumer_ids = var.remote_state_consumer_ids
-
-
-  agent_pool_id = var.execution_mode == "agent" ? var.agent_pool_id : null
 }
 


### PR DESCRIPTION
Previously, the `tfe_workspace_settings` resource was invoked upon Workspace creation because it did not have count set.  This change introduces a performance enhancement as it should not be necessary to create this additional resource unless a user explicitly specifies a an input corresponding to this resource:

- `var.execution_mode` 
- `var.global_remote_state`
- `var.remote_state_consumer_ids`

If any of these inputs are not `null`, then the resource will be invoked.  Otherwise, it will be skipped.

